### PR TITLE
chore(build): reorder node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ cache:
 notifications:
   email: false
 node_js:
-  - '6'
-  - '5'
   - '4'
+  - '5'
+  - '6'
   - '0.12'
   - '0.10'
 before_install:


### PR DESCRIPTION
hope, that has the side effect of not publishing from a container running Node 6, due to https://github.com/npm/npm/issues/5082